### PR TITLE
修复由于postRS未定义导致的bug

### DIFF
--- a/ddnspod/ddnspod/scripts/ddnspod_config.sh
+++ b/ddnspod/ddnspod/scripts/ddnspod_config.sh
@@ -54,7 +54,7 @@ arDdnsUpdate() {
 }
 
 arDdnsCheck() {
-	postRS
+	local postRS
 	hostIP=$(arIpAdress)
 	lastIP=$(arNslookup "${2}.${1}")
 	echo "hostIP: ${hostIP}"


### PR DESCRIPTION
由于postRS变量未定义导致脚本运行失败