### PR TITLE
fix 401 Unauthorized for hass 0.109.6

### DIFF
--- a/routerhook/routerhook/scripts/routerhook_sender.sh
+++ b/routerhook/routerhook/scripts/routerhook_sender.sh
@@ -5,7 +5,7 @@ routerhook_var_timestamp=$(date '+%s')
 routerhook_var_gmt=$(date -u '+%a, %d %b %Y %T GMT')
 
 replace_var() {
-    temp_var=$1
+    temp_var=$@
     temp_var=${temp_var//_PRM_EVENT/$msg_type}
     temp_var=${temp_var//_PRM_DT/$routerhook_var_gmt}
     temp_var=${temp_var//_PRM_TS/$routerhook_var_timestamp}


### PR DESCRIPTION
提示：401: Unauthorized。
请求头部Authorization中需要增加Bearer asdfasdfasfasa，格式中间必须有空格，Bearer是固定的，但脚本中拼接curl时，截断了空格，所以 鉴权失败！

详见https://koolshare.cn/thread-178114-3-1.html的58楼