### PR TITLE
修复特殊子域名导致无法获取到当前A记录

### DIFF
--- a/ddnspod/ddnspod/scripts/ddnspod_config.sh
+++ b/ddnspod/ddnspod/scripts/ddnspod_config.sh
@@ -56,7 +56,12 @@ arDdnsUpdate() {
 arDdnsCheck() {
 	local postRS
 	hostIP=$(arIpAdress)
-	lastIP=$(arNslookup "${2}.${1}")
+	if [ $2 == "@" ];then
+		lastIP=$(arNslookup "${1}")
+		echo "Spetial subDomain: $2"
+	else
+		lastIP=$(arNslookup "${2}.${1}")
+	fi
 	echo "hostIP: ${hostIP}"
 	echo "lastIP: ${lastIP}"
 	if [ "$lastIP" != "$hostIP" ]; then


### PR DESCRIPTION
修正：子域名为@时，获取到的lastIP为空，会一直更新A记录。