### PR TITLE
tailscale SNAT

### DIFF
--- a/tailscale/Changelog.txt
+++ b/tailscale/Changelog.txt
@@ -1,3 +1,7 @@
+script是乱码, 不知道怎么提PR, 说下问题:
+  iptables 未加入SNAT, 会导致访问tailnet中其他node时, 数据包无法返回
+  例: iptables -t nat -A POSTROUTING ! -s 192.168.50.1/32 -o tailscale0 -j MASQUERADE
+
 Koolshare Asuswrt-Merlin ZeroTier Changelog for HND/AXHND platform
 ===========================================
 1.8


### PR DESCRIPTION
建议script增加SNAT, 否则无法此路由器的客户端无法访问组网中的其他subnet网段
例: `iptables -t nat -A POSTROUTING ! -s 192.168.50.1/32 -o tailscale0 -j MASQUERADE`