### PR TITLE
modify update function so it can update both of ipv4 and ipv6

### DIFF
--- a/cfddns/cfddns/scripts/cfddns_config.sh
+++ b/cfddns/cfddns/scripts/cfddns_config.sh
@@ -123,7 +123,10 @@ start)
 	fi
 	;;
 update)
-	check_update >> $LOG_FILE
+	check_update 4 >> $LOG_FILE
+	if [ "$cfddns_ipv6" == "1" ];then
+		check_update 6 >> $LOG_FILE
+	fi
 	;;
 esac
 # ====================================submit by web====================================


### PR DESCRIPTION
currently the 'update' script only update the ip which last update work updated. it casue an issue like if you enabled both of ipv4 and ipv6 it will only update ipv6 address. this PR is attend to fix that