### PR TITLE
fix(usb2jffs): 修复RT-AX89X(内核4.4+ubifs)和entware环境下的多个兼容性问题

### DIFF
--- a/usb2jffs/usb2jffs/init.d/M01usb2jffs.sh
+++ b/usb2jffs/usb2jffs/init.d/M01usb2jffs.sh
@@ -135,7 +135,7 @@ JFFS2USB(){
 	# 防止用户在路由器开机状态，并且已经替换了JFFS为USB的情况下，再插入一个有.koolshare_jffs目录的USB储存设备导致重复挂载
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" == "2" ]; then
+	if [ "${mounted_nu}" -ge "2" ]; then
 		# echo_date "USB2JFFS：检测到你的USB磁盘${jffs_device}已经挂载在/jffs上了，跳过！"
 		return 1
 	fi
@@ -290,7 +290,7 @@ JFFS2USB(){
 		nvram commit
 
 		# 把原来的jffs分区挂载到cifs
-		if [ "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
+		if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
 			mount -t ubifs ${mtd_disk} /cifs2
 		else
 			mount -t jffs2 -o rw,noatime ${mtd_disk} /cifs2

--- a/usb2jffs/usb2jffs/scripts/usb2jffs_config.sh
+++ b/usb2jffs/usb2jffs/scripts/usb2jffs_config.sh
@@ -303,7 +303,8 @@ start_usb2jffs(){
 	
 		# 把原来的jffs分区挂载到cifs2
 		echo_date "将${mtd_disk}挂载在/cifs2"
-		if [ "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
+		umount -l /cifs2 2>/dev/null
+		if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
 			mount -t ubifs ${mtd_disk} /cifs2
 		else
 			mount -t jffs2 -o rw,noatime ${mtd_disk} /cifs2
@@ -320,7 +321,7 @@ start_usb2jffs(){
 	else
 		echo_date "USB型JFFS挂载失败！！"
 		echo_date "尝试恢复原始挂载方式！"
-		if [ "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
+		if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
 			mount -t ubifs ${mtd_disk} /jffs
 		else
 			mount -t jffs2 -o rw,noatime ${mtd_disk} /jffs
@@ -343,7 +344,7 @@ stop_usb2jffs(){
 	# 检测是否有USB磁盘挂载在/jffs上
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "$mounted_nu" == "2" ]; then
+	if [ "$mounted_nu" -ge "2" ]; then
 		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | awk '{print $3}')
 		echo_date "检测到USB磁盘的${usb_path}/.koolshare_jffs挂载在/jffs上"
 	else
@@ -401,7 +402,7 @@ stop_usb2jffs(){
 	if [ "$?" == "0" ]; then
 		echo_date "/jffs卸载成功..."
 		echo_date "将文件系统${mtd_disk}挂载到jffs分区..."
-		if [ "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
+		if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
 			mount -t ubifs ${mtd_disk} /jffs
 		else
 			mount -t jffs2 -o rw,noatime ${mtd_disk} /jffs
@@ -444,7 +445,7 @@ sync_usb_mtd(){
 	# 检测是否有USB磁盘挂载在/jffs上
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" == "2" ]; then
+	if [ "${mounted_nu}" -ge "2" ]; then
 		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | awk '{print $3}')
 		#echo_date "检测到USB磁盘的${usb_path}/.koolshare_jffs挂载在/jffs上"
 	else
@@ -591,7 +592,7 @@ del_sync_job(){
 set_sync_job(){
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" == "2" ]; then
+	if [ "${mounted_nu}" -ge "2" ]; then
 		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | awk '{print $3}')
 		#echo_date "检测到USB磁盘的${usb_path}/.koolshare_jffs挂载在/jffs上"
 	else
@@ -634,7 +635,7 @@ set_sync_job(){
 set_stop_sync(){
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" == "2" ]; then
+	if [ "${mounted_nu}" -ge "2" ]; then
 		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | awk '{print $3}')
 		#echo_date "检测到USB磁盘的${usb_path}/.koolshare_jffs挂载在/jffs上"
 	else
@@ -664,7 +665,7 @@ make_backup(){
 	fi
 	
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" != "2" ]; then
+	if [ "${mounted_nu}" -lt "2" ]; then
 		echo_date "错误！没有检测到USB磁盘挂载在/jffs，无法备份！"
 		echo_date "请先挂载USB磁盘到/jffs后再使用本功能！"
 		return 1
@@ -744,7 +745,7 @@ restore_backup(){
 	fi
 	
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs"|/bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" != "2" ]; then
+	if [ "${mounted_nu}" -lt "2" ]; then
 		echo_date "错误！没有检测到USB磁盘挂载在/jffs，无法恢复！"
 		echo_date "请先挂载USB磁盘到/jffs后再使用本功能！"
 		return 1

--- a/usb2jffs/usb2jffs/scripts/usb2jffs_mount_status.sh
+++ b/usb2jffs/usb2jffs/scripts/usb2jffs_mount_status.sh
@@ -29,8 +29,8 @@ get_current_jffs_device(){
 start(){
 	get_current_jffs_device
 	local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs" | /bin/grep -v "DockRootData" | /bin/grep -c "/dev/s")
-	if [ "${mounted_nu}" -eq "2" ]; then
-		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | /bin/grep -v "DockRootData" | awk '{print $3}')
+	if [ "${mounted_nu}" -ge "2" ]; then
+		local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | /bin/grep -v "DockRootData" | /bin/grep -v "asusware" | awk '{print $3}' | head -n1)
 		http_response "$(get_current_jffs_status)@@jffs挂载路径：<em>${usb_path}/.koolshare_jffs → /jffs</em>@@1"
 	else
 		if [ -d "${usb2jffs_mount_path}/.koolshare_jffs" ];then


### PR DESCRIPTION
## 问题描述

RT-AX89X 路由器在使用 USB2JFFS 插件时存在多个兼容性问题，导致：
- `/cifs2` 挂载失败，同步功能不可用
- WebUI 始终显示"尚未挂载"（实际已挂载成功）
- WebUI 状态检测页面卡死在"检测状态中..."

**设备信息**：RT-AX89X，内核 4.4.60，JFFS 分区为 ubifs 格式，已安装 entware (amtm)

---

## Bug 1：LINUX_VER 判断缺少内核 4.4 的 ubifs 支持

### 复现条件
RT-AX89X 内核版本为 `4.4.60`，`LINUX_VER` 计算结果为 `44`。

### 根因
代码中仅在 `LINUX_VER` 为 `419`（4.19）或 `54`（5.4）时使用 `mount -t ubifs` 挂载 `/cifs2`，否则使用 `mount -t jffs2`。

RT-AX89X 虽然内核是 4.4（IPQ8074 平台），但其 JFFS 分区实际使用的是 **ubifs 格式**（可通过 `dmesg | grep UBIFS` 确认：`UBIFS: mounted UBI device 0, volume 5, name "jffs2"`），而非传统 4.4 内核机型常用的 jffs2 格式。

因此插件走了 `else` 分支，使用 `jffs2` 格式去挂载 ubifs 分区，类型不匹配导致挂载失败。

### 修复
在所有 `LINUX_VER` 判断条件中增加 `"44"`：
```diff
-if [ "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
+if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
```

**涉及文件**：
- `usb2jffs_config.sh`：第 306、324、405 行（共 3 处）
- `M01usb2jffs.sh`：第 293 行（共 1 处）

---

## Bug 2：`mounted_nu` 硬编码为 2 导致 entware 环境下检测失败

### 复现条件
安装了 entware (amtm) 的设备，USB 分区上存在 `asusware.arm` 的 bind mount。

### 根因
插件通过以下方式检测 USB 是否挂载到 `/jffs`：
```bash
local mounted_nu=$(mount | /bin/grep "${jffs_device}" | grep -E "/tmp/mnt/|/jffs" | /bin/grep -c "/dev/s")
```
预期 `mounted_nu == 2`（一个是 `/tmp/mnt/ew`，另一个是 `/jffs`）。

但 entware 会额外创建一个 bind mount：
```
/dev/sda1 on /tmp/mnt/ew type ext4 (rw,nodev,noatime,data=ordered)
/dev/sda1 on /tmp/mnt/ew/asusware.arm type ext4 (rw,relatime,data=ordered)  ← 多出来的
/dev/sda1 on /jffs type ext4 (rw,nodev,noatime,data=ordered)
```

导致 `mounted_nu = 3`，所有 `== "2"` 的判断全部为 false，表现为：
- WebUI 显示"尚未挂载"
- 同步/备份/恢复功能报错"没有检测到任何挂载在/jffs上的USB磁盘设备"
- 卸载功能无法识别已挂载的 USB 设备

### 修复
- 正向判断（检测是否已挂载）：`== "2"` 改为 `-ge "2"`
- 反向判断（检测是否未挂载）：`!= "2"` 改为 `-lt "2"`

**涉及文件**：
- `usb2jffs_config.sh`：第 346、447、594、637 行改为 `-ge`；第 667、747 行改为 `-lt`
- `M01usb2jffs.sh`：第 138 行改为 `-ge`
- `usb2jffs_mount_status.sh`：第 32 行改为 `-ge`

---

## Bug 3：手动挂载时 `/cifs2` 重复挂载失败

### 复现条件
开机自动挂载（M01usb2jffs.sh）已成功将 `/cifs2` 挂载后，用户在 WebUI 手动点击"挂载"按钮。

### 根因
`start_usb2jffs()` 函数在挂载 `/cifs2` 前没有检查其是否已被挂载，直接执行 `mount` 命令。如果 `/cifs2` 已经被占用（如开机时 M01 已挂载），则 mount 必然失败。

### 修复
在挂载 `/cifs2` 之前先执行 `umount -l /cifs2 2>/dev/null`：
```diff
 		echo_date "将${mtd_disk}挂载在/cifs2"
+		umount -l /cifs2 2>/dev/null
 		if [ "${LINUX_VER}" == "44" -o "${LINUX_VER}" == "419" -o "${LINUX_VER}" == "54" ];then
```

**涉及文件**：
- `usb2jffs_config.sh`：第 305 行后插入

---

## Bug 4：`usb_path` 多行导致 WebUI 状态检测卡死

### 复现条件
安装了 entware (amtm) 的设备访问 USB2JFFS 插件 WebUI 页面。

### 根因
`usb2jffs_mount_status.sh` 中获取 `usb_path` 时：
```bash
local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | /bin/grep -v "DockRootData" | awk '{print $3}')
```
由于 `asusware.arm` 的 bind mount，grep 匹配到两行：
```
/tmp/mnt/ew
/tmp/mnt/ew/asusware.arm
```
`usb_path` 变量包含多行内容，传入 `http_response` 后 curl POST 数据格式损坏，httpdb 返回 `{"result":-1}`，WebUI 永远卡在"检测状态中..."。

### 修复
增加 `asusware` 过滤和 `head -n1` 限制：
```diff
-local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | /bin/grep -v "DockRootData" | awk '{print $3}')
+local usb_path=$(mount | /bin/grep "${jffs_device}" | /bin/grep "/tmp/mnt/" | /bin/grep -v "DockRootData" | /bin/grep -v "asusware" | awk '{print $3}' | head -n1)
```

**涉及文件**：
- `usb2jffs_mount_status.sh`：第 33 行

---

## 修改文件汇总

| 文件 | 修改点数 |
|------|---------|
| `usb2jffs/usb2jffs/scripts/usb2jffs_config.sh` | 10 处 |
| `usb2jffs/usb2jffs/init.d/M01usb2jffs.sh` | 2 处 |
| `usb2jffs/usb2jffs/scripts/usb2jffs_mount_status.sh` | 2 处 |

## 测试验证
- RT-AX89X 真机测试通过
- WebUI 挂载/状态检测/同步功能均正常
- 重启后自动挂载正常
